### PR TITLE
Added support for Seamless Coop mod .co2 savegame files.

### DIFF
--- a/EldenRingSaveCopy/Form1.Designer.cs
+++ b/EldenRingSaveCopy/Form1.Designer.cs
@@ -52,9 +52,10 @@ namespace EldenRingSaveCopy
             // 
             // sourceFileLoad
             // 
-            this.sourceFileLoad.Location = new System.Drawing.Point(335, 273);
+            this.sourceFileLoad.Location = new System.Drawing.Point(19, 399);
+            this.sourceFileLoad.Margin = new System.Windows.Forms.Padding(4);
             this.sourceFileLoad.Name = "sourceFileLoad";
-            this.sourceFileLoad.Size = new System.Drawing.Size(75, 23);
+            this.sourceFileLoad.Size = new System.Drawing.Size(242, 28);
             this.sourceFileLoad.TabIndex = 0;
             this.sourceFileLoad.Text = "Browse";
             this.sourceFileLoad.UseVisualStyleBackColor = true;
@@ -62,46 +63,51 @@ namespace EldenRingSaveCopy
             // 
             // sourceFilePath
             // 
-            this.sourceFilePath.Location = new System.Drawing.Point(95, 274);
+            this.sourceFilePath.Location = new System.Drawing.Point(19, 435);
+            this.sourceFilePath.Margin = new System.Windows.Forms.Padding(4);
             this.sourceFilePath.Name = "sourceFilePath";
-            this.sourceFilePath.Size = new System.Drawing.Size(234, 20);
+            this.sourceFilePath.ReadOnly = true;
+            this.sourceFilePath.Size = new System.Drawing.Size(242, 22);
             this.sourceFilePath.TabIndex = 1;
-            this.sourceFilePath.TextChanged += new System.EventHandler(this.sourceFilePath_TextChanged);
             // 
             // label1
             // 
             this.label1.AutoSize = true;
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
-            this.label1.Location = new System.Drawing.Point(32, 278);
+            this.label1.Location = new System.Drawing.Point(90, 366);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(57, 13);
+            this.label1.Size = new System.Drawing.Size(99, 24);
             this.label1.TabIndex = 2;
             this.label1.Text = "Source file";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
+            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
-            this.label2.Location = new System.Drawing.Point(13, 318);
+            this.label2.Location = new System.Drawing.Point(372, 366);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(76, 13);
+            this.label2.Size = new System.Drawing.Size(130, 24);
             this.label2.TabIndex = 5;
             this.label2.Text = "Destination file";
-            this.label2.Click += new System.EventHandler(this.label2_Click);
             // 
             // targetFilePath
             // 
-            this.targetFilePath.Location = new System.Drawing.Point(95, 314);
+            this.targetFilePath.Location = new System.Drawing.Point(337, 435);
+            this.targetFilePath.Margin = new System.Windows.Forms.Padding(4);
             this.targetFilePath.Name = "targetFilePath";
-            this.targetFilePath.Size = new System.Drawing.Size(234, 20);
+            this.targetFilePath.Size = new System.Drawing.Size(242, 22);
             this.targetFilePath.TabIndex = 4;
-            this.targetFilePath.TextChanged += new System.EventHandler(this.textBox2_TextChanged);
             // 
             // destinationFileLoad
             // 
-            this.destinationFileLoad.Location = new System.Drawing.Point(335, 313);
+            this.destinationFileLoad.Location = new System.Drawing.Point(337, 399);
+            this.destinationFileLoad.Margin = new System.Windows.Forms.Padding(4);
             this.destinationFileLoad.Name = "destinationFileLoad";
-            this.destinationFileLoad.Size = new System.Drawing.Size(75, 23);
+            this.destinationFileLoad.Size = new System.Drawing.Size(242, 28);
             this.destinationFileLoad.TabIndex = 3;
             this.destinationFileLoad.Text = "Browse";
             this.destinationFileLoad.UseVisualStyleBackColor = true;
@@ -110,10 +116,11 @@ namespace EldenRingSaveCopy
             // pictureBox1
             // 
             this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
-            this.pictureBox1.Location = new System.Drawing.Point(0, 25);
+            this.pictureBox1.Location = new System.Drawing.Point(16, 61);
             this.pictureBox1.Margin = new System.Windows.Forms.Padding(0);
             this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(450, 220);
+            this.pictureBox1.Size = new System.Drawing.Size(563, 247);
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this.pictureBox1.TabIndex = 6;
             this.pictureBox1.TabStop = false;
             // 
@@ -131,10 +138,11 @@ namespace EldenRingSaveCopy
             "Slot 8",
             "Slot 9",
             "Slot 10"});
-            this.fromSaveSlot.Location = new System.Drawing.Point(63, 397);
+            this.fromSaveSlot.Location = new System.Drawing.Point(19, 491);
+            this.fromSaveSlot.Margin = new System.Windows.Forms.Padding(4);
             this.fromSaveSlot.MaxDropDownItems = 11;
             this.fromSaveSlot.Name = "fromSaveSlot";
-            this.fromSaveSlot.Size = new System.Drawing.Size(121, 21);
+            this.fromSaveSlot.Size = new System.Drawing.Size(242, 24);
             this.fromSaveSlot.TabIndex = 7;
             this.fromSaveSlot.SelectedIndexChanged += new System.EventHandler(this.fromSaveSlot_SelectedIndexChanged);
             // 
@@ -146,19 +154,19 @@ namespace EldenRingSaveCopy
             this.titleBar.Location = new System.Drawing.Point(0, 0);
             this.titleBar.Margin = new System.Windows.Forms.Padding(0);
             this.titleBar.Name = "titleBar";
-            this.titleBar.Size = new System.Drawing.Size(450, 25);
+            this.titleBar.Size = new System.Drawing.Size(600, 31);
             this.titleBar.TabIndex = 8;
-            this.titleBar.Paint += new System.Windows.Forms.PaintEventHandler(this.titlePanel);
             // 
             // title
             // 
             this.title.AutoSize = true;
             this.title.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.title.Location = new System.Drawing.Point(157, 4);
+            this.title.Location = new System.Drawing.Point(209, 5);
+            this.title.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.title.Name = "title";
-            this.title.Size = new System.Drawing.Size(136, 16);
+            this.title.Size = new System.Drawing.Size(140, 16);
             this.title.TabIndex = 10;
-            this.title.Text = "Save game copy tool";
+            this.title.Text = "Savegame Copy Tool";
             // 
             // exitButton
             // 
@@ -166,10 +174,10 @@ namespace EldenRingSaveCopy
             this.exitButton.FlatAppearance.BorderSize = 0;
             this.exitButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.exitButton.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.exitButton.Location = new System.Drawing.Point(426, 0);
+            this.exitButton.Location = new System.Drawing.Point(568, 0);
             this.exitButton.Margin = new System.Windows.Forms.Padding(0);
             this.exitButton.Name = "exitButton";
-            this.exitButton.Size = new System.Drawing.Size(24, 24);
+            this.exitButton.Size = new System.Drawing.Size(32, 30);
             this.exitButton.TabIndex = 9;
             this.exitButton.Text = "X";
             this.exitButton.UseVisualStyleBackColor = true;
@@ -178,24 +186,26 @@ namespace EldenRingSaveCopy
             // label3
             // 
             this.label3.AutoSize = true;
+            this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
-            this.label3.Location = new System.Drawing.Point(96, 372);
+            this.label3.Location = new System.Drawing.Point(101, 461);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(54, 13);
+            this.label3.Size = new System.Drawing.Size(72, 17);
             this.label3.TabIndex = 9;
             this.label3.Text = "Copy from";
-            this.label3.Click += new System.EventHandler(this.label3_Click);
             // 
             // label4
             // 
             this.label4.AutoSize = true;
+            this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label4.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
-            this.label4.Location = new System.Drawing.Point(300, 372);
+            this.label4.Location = new System.Drawing.Point(428, 461);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(43, 13);
+            this.label4.Size = new System.Drawing.Size(56, 17);
             this.label4.TabIndex = 11;
             this.label4.Text = "Copy to";
-            this.label4.Click += new System.EventHandler(this.label4_Click);
             // 
             // toSaveSlot
             // 
@@ -211,45 +221,47 @@ namespace EldenRingSaveCopy
             "Slot 8",
             "Slot 9",
             "Slot 10"});
-            this.toSaveSlot.Location = new System.Drawing.Point(261, 397);
+            this.toSaveSlot.Location = new System.Drawing.Point(337, 491);
+            this.toSaveSlot.Margin = new System.Windows.Forms.Padding(4);
             this.toSaveSlot.MaxDropDownItems = 11;
             this.toSaveSlot.Name = "toSaveSlot";
-            this.toSaveSlot.Size = new System.Drawing.Size(121, 21);
+            this.toSaveSlot.Size = new System.Drawing.Size(242, 24);
             this.toSaveSlot.TabIndex = 10;
             this.toSaveSlot.SelectedIndexChanged += new System.EventHandler(this.toSaveSlot_SelectedIndexChanged);
             // 
             // copyButton
             // 
-            this.copyButton.BackColor = System.Drawing.Color.SeaGreen;
+            this.copyButton.BackColor = System.Drawing.Color.DarkOrange;
             this.copyButton.Enabled = false;
             this.copyButton.FlatAppearance.BorderSize = 0;
             this.copyButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.copyButton.Location = new System.Drawing.Point(126, 633);
+            this.copyButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.copyButton.Location = new System.Drawing.Point(19, 536);
+            this.copyButton.Margin = new System.Windows.Forms.Padding(4);
             this.copyButton.Name = "copyButton";
-            this.copyButton.Size = new System.Drawing.Size(199, 37);
+            this.copyButton.Size = new System.Drawing.Size(560, 54);
             this.copyButton.TabIndex = 12;
-            this.copyButton.Text = "Copy";
+            this.copyButton.Text = "Select Source and Destination files";
             this.copyButton.UseVisualStyleBackColor = false;
             this.copyButton.Click += new System.EventHandler(this.copyButton_Click);
             // 
             // additionalInfoLabel
             // 
-            this.additionalInfoLabel.AutoSize = true;
             this.additionalInfoLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
-            this.additionalInfoLabel.Location = new System.Drawing.Point(38, 678);
+            this.additionalInfoLabel.Location = new System.Drawing.Point(16, 317);
+            this.additionalInfoLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.additionalInfoLabel.Name = "additionalInfoLabel";
-            this.additionalInfoLabel.Size = new System.Drawing.Size(375, 13);
+            this.additionalInfoLabel.Size = new System.Drawing.Size(563, 49);
             this.additionalInfoLabel.TabIndex = 13;
             this.additionalInfoLabel.Text = "Ensure the ER0000.bak file has been deleted from save folder prior to loading.";
-            this.additionalInfoLabel.Visible = false;
-            this.additionalInfoLabel.Click += new System.EventHandler(this.label5_Click);
+            this.additionalInfoLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // Form1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(46)))), ((int)(((byte)(51)))), ((int)(((byte)(73)))));
-            this.ClientSize = new System.Drawing.Size(450, 700);
+            this.ClientSize = new System.Drawing.Size(597, 617);
             this.Controls.Add(this.additionalInfoLabel);
             this.Controls.Add(this.copyButton);
             this.Controls.Add(this.label4);
@@ -258,13 +270,14 @@ namespace EldenRingSaveCopy
             this.Controls.Add(this.titleBar);
             this.Controls.Add(this.fromSaveSlot);
             this.Controls.Add(this.pictureBox1);
-            this.Controls.Add(this.label2);
             this.Controls.Add(this.targetFilePath);
             this.Controls.Add(this.destinationFileLoad);
-            this.Controls.Add(this.label1);
             this.Controls.Add(this.sourceFilePath);
             this.Controls.Add(this.sourceFileLoad);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.label2);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "Form1";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Form1";

--- a/EldenRingSaveCopy/Form1.Designer.cs
+++ b/EldenRingSaveCopy/Form1.Designer.cs
@@ -241,7 +241,7 @@ namespace EldenRingSaveCopy
             this.copyButton.Name = "copyButton";
             this.copyButton.Size = new System.Drawing.Size(560, 54);
             this.copyButton.TabIndex = 12;
-            this.copyButton.Text = "Select Source and Destination files";
+            this.copyButton.Text = "Select Source and Destination file and characters";
             this.copyButton.UseVisualStyleBackColor = false;
             this.copyButton.Click += new System.EventHandler(this.copyButton_Click);
             // 

--- a/EldenRingSaveCopy/Form1.cs
+++ b/EldenRingSaveCopy/Form1.cs
@@ -11,6 +11,8 @@ using System.Runtime.InteropServices;
 using System.IO;
 using System.Security.Cryptography;
 using EldenRingSaveCopy.Saves.Model;
+using System.Runtime.CompilerServices;
+using System.Security.Policy;
 
 namespace EldenRingSaveCopy
 {
@@ -20,6 +22,10 @@ namespace EldenRingSaveCopy
 
         public const int WM_NCLBUTTONDOWN = 0xA1;
         public const int HT_CAPTION = 0x2;
+
+        private const int MESSAGE_ERROR = 0;
+        private const int MESSAGE_INFO = 1;
+        private const int MESSAGE_SUCCESS = 2;
 
         private BindingList<ISaveGame> sourceSaveGames = new BindingList<ISaveGame>();
         private BindingList<ISaveGame> targetSaveGames = new BindingList<ISaveGame>();
@@ -46,13 +52,30 @@ namespace EldenRingSaveCopy
         public Form1()
         {
             InitializeComponent();
+            showAdditionalInfoMessage(MESSAGE_INFO, "Select Source and Destination files and characters");
+        }
+
+        // Tries to read the current windows user name and if it suceeds at it, it uses it in the default Elden Ring savefile location
+        private void setCurrentUserDirectory(ref OpenFileDialog currentDialog)
+        {
+            string nameDirectory = null;
+            try
+            {
+                nameDirectory = "C:\\Users\\" + Environment.UserName + "\\AppData\\Roaming\\EldenRing";
+                currentDialog.InitialDirectory = "C:\\Users\\MemoGaming\\AppData\\Roaming\\EldenRing";
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+            }
         }
 
         private void sourceFileBrowse(object sender, EventArgs e)
         {
             sourceSaveGames.Clear();
             OpenFileDialog openFileDialog = new OpenFileDialog();
-            openFileDialog.Filter = "Elden Ring Save File |ER0000.sl2";
+            setCurrentUserDirectory(ref openFileDialog);
+            openFileDialog.Filter = "Elden Ring Save File |ER0000.sl2|Elden Ring Coop Save File |ER0000.co2";
             DialogResult result = openFileDialog.ShowDialog(); // Show the dialog.
             if (result == DialogResult.OK) // Test result.
             {
@@ -71,10 +94,18 @@ namespace EldenRingSaveCopy
                             sourceSaveGames.Add(newSave);
                         }
                     }
+
+                    if(sourceSaveGames.Count > 0)
+                    {
+                        fromSaveSlot.SelectedIndex = 0;
+                        this.selectedSourceSave = (ISaveGame)fromSaveSlot.SelectedItem;
+                        showAdditionalInfoMessage(MESSAGE_INFO, "Source savegame file loaded correctly.");
+                    }
                 }
                 catch (IOException)
                 {
                     sourceFilePath.Text = "Failed to load";
+                    showAdditionalInfoMessage(MESSAGE_ERROR, "Source savegame file failed to load.");
                 }
             }
             CheckButtonState();
@@ -84,7 +115,8 @@ namespace EldenRingSaveCopy
         {
             targetSaveGames.Clear();
             OpenFileDialog openFileDialog = new OpenFileDialog();
-            openFileDialog.Filter = "Elden Ring Save File |ER0000.sl2";
+            setCurrentUserDirectory(ref openFileDialog);
+            openFileDialog.Filter = "Elden Ring Save File |ER0000.sl2|Elden Ring Coop Save File |ER0000.co2";
             DialogResult result = openFileDialog.ShowDialog();
             if (result == DialogResult.OK)
             {
@@ -104,10 +136,17 @@ namespace EldenRingSaveCopy
                         }
                         targetSaveGames.Add(newSave);
                     }
+                    if (targetSaveGames.Count > 0)
+                    {
+                        toSaveSlot.SelectedIndex = 0;
+                        this.selectedTargetSave = (ISaveGame)toSaveSlot.SelectedItem;
+                        showAdditionalInfoMessage(MESSAGE_INFO, "Destination savegame file loaded correctly.");
+                    }
                 }
                 catch (IOException)
                 {
                     sourceFilePath.Text = "Failed to load";
+                    showAdditionalInfoMessage(MESSAGE_ERROR, "Destination savegame file failed to load.");
                 }
             }
             CheckButtonState();
@@ -115,22 +154,21 @@ namespace EldenRingSaveCopy
 
         private void CheckButtonState()
         {
-            copyButton.Text = "Copy";
-            additionalInfoLabel.Visible = false;
             if (_fileManager.SourceFile.Length > 0 && _fileManager.TargetFile.Length > 0 
                 && _fileManager.SourcePath != _fileManager.TargetPath &&
                 this.selectedSourceSave.Id != Guid.Empty && this.selectedTargetSave.Id != Guid.Empty)
             {
                 copyButton.Enabled = true;
-                copyButton.BackColor = Color.Lime;
+                copyButton.BackColor = Color.Gold;
+                copyButton.Text = "Copy Selected Character";
             }
             else
             {
                 copyButton.Enabled = false;
-                copyButton.BackColor = Color.SeaGreen;
+                copyButton.BackColor = Color.DarkOrange;
+                copyButton.Text = "Select Source and Destination file and characters";
             }
         }
-
         private void Form1_Load(object sender, EventArgs e)
         {
             titleBar.MouseDown += Form1_MouseDown;
@@ -221,8 +259,6 @@ namespace EldenRingSaveCopy
                     Array.Copy(md5.Hash, 0, newSave, SaveGame.SAVE_HEADERS_SECTION_START_INDEX - 0x10, 0x10);
                 }
 
-                
-
                 //Write temp file to target file
                 File.WriteAllBytes(_fileManager.TargetPath, newSave);
 
@@ -235,19 +271,40 @@ namespace EldenRingSaveCopy
 
                 //Indicate successful copy
                 copyButton.Enabled = false;
-                copyButton.Text = "Complete";
-                copyButton.BackColor = Color.SeaGreen;
-                additionalInfoLabel.Visible = true;
+                copyButton.Text = "Copy Successful!";
+                copyButton.BackColor = Color.Gold;
+                showAdditionalInfoMessage(MESSAGE_SUCCESS, "Ensure the ER0000.bak file has been deleted from save folder prior to loading.");
             }
             catch (Exception _e)
             {
                 copyButton.Enabled = false;
-                copyButton.Text = "Failed";
-                copyButton.BackColor = Color.DarkRed;
+                copyButton.Text = "Copy Failed!";
+                copyButton.BackColor = Color.DarkOrange;
                 byte[] err = Encoding.Default.GetBytes(_e.Message);
                 File.WriteAllBytes(_fileManager.TargetPath.Replace("ER0000.sl2", "Error.log"), err);
             }
             
+        }
+
+        private void showAdditionalInfoMessage(int type, string message)
+        {
+            additionalInfoLabel.Text = message;
+            switch (type)
+            {
+                case MESSAGE_ERROR:
+                    additionalInfoLabel.ForeColor = Color.DarkOrange;
+                    break;
+                case MESSAGE_INFO:
+                    additionalInfoLabel.ForeColor = Color.White;
+                    break;
+                case MESSAGE_SUCCESS:
+                    additionalInfoLabel.ForeColor = Color.Gold;
+                    break;
+                default:
+                    additionalInfoLabel.ForeColor= Color.White;
+                    break;
+
+            }
         }
 
         private void exitButtonClick(object sender, EventArgs e)
@@ -255,39 +312,5 @@ namespace EldenRingSaveCopy
             this.Close();
         }
 
-        private void label2_Click(object sender, EventArgs e)
-        {
-
-        }
-
-        private void sourceFilePath_TextChanged(object sender, EventArgs e)
-        {
-
-        }
-
-        private void titlePanel(object sender, PaintEventArgs e)
-        {
-
-        }
-
-        private void label3_Click(object sender, EventArgs e)
-        {
-
-        }
-
-        private void label4_Click(object sender, EventArgs e)
-        {
-
-        }
-
-        private void textBox2_TextChanged(object sender, EventArgs e)
-        {
-
-        }
-
-        private void label5_Click(object sender, EventArgs e)
-        {
-
-        }
     }
 }

--- a/EldenRingSaveCopy/Form1.cs
+++ b/EldenRingSaveCopy/Form1.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Data;
 using System.Drawing;
 using System.Linq;
 using System.Text;
@@ -11,8 +9,6 @@ using System.Runtime.InteropServices;
 using System.IO;
 using System.Security.Cryptography;
 using EldenRingSaveCopy.Saves.Model;
-using System.Runtime.CompilerServices;
-using System.Security.Policy;
 
 namespace EldenRingSaveCopy
 {
@@ -159,8 +155,13 @@ namespace EldenRingSaveCopy
                 this.selectedSourceSave.Id != Guid.Empty && this.selectedTargetSave.Id != Guid.Empty)
             {
                 copyButton.Enabled = true;
-                copyButton.BackColor = Color.Gold;
-                copyButton.Text = "Copy Selected Character";
+                copyButton.BackColor = Color.Goldenrod;
+                copyButton.Text =
+                    "Copy source character "
+                    + (this.selectedSourceSave.CharacterName.Contains("Slot ") ? this.selectedSourceSave.CharacterName :
+                    this.selectedSourceSave.CharacterName.Split('\0')[0])
+                    + (this.selectedTargetSave.CharacterName.Contains("Slot ") ? " on destination file " + this.selectedTargetSave.CharacterName :
+                    " over destination character " + this.selectedTargetSave.CharacterName.Split('\0')[0]);
             }
             else
             {


### PR DESCRIPTION
1. UI update and option to select .co2 savegame files:
![image](https://user-images.githubusercontent.com/5017552/195966717-103e51b0-3dc8-43bb-acde-391df0ff38c7.png)

2. Added more explicit copy button label messages:
![image](https://user-images.githubusercontent.com/5017552/195967983-1160e21e-7aaf-4188-945b-792e615ded75.png)
![image](https://user-images.githubusercontent.com/5017552/195967988-cdee964f-3fa2-47ea-b8ad-ebad55e6ee41.png)

3. Other modifications:
   - Automatically tries to find and open the default Elden Ring savegame folder for the current Windows user
   - Automatically selects first combo box element when correctly loaded a savegame file