### PR TITLE
Added dialog default file type selection for both *.sl2 and *.co2

### DIFF
--- a/EldenRingSaveCopy/Form1.cs
+++ b/EldenRingSaveCopy/Form1.cs
@@ -71,7 +71,8 @@ namespace EldenRingSaveCopy
             sourceSaveGames.Clear();
             OpenFileDialog openFileDialog = new OpenFileDialog();
             setCurrentUserDirectory(ref openFileDialog);
-            openFileDialog.Filter = "Elden Ring Save File |ER0000.sl2|Elden Ring Coop Save File |ER0000.co2";
+            openFileDialog.Filter = "All Elden Ring Save File Types|*.sl2;*.co2|"
+            + "Elden Ring Save File|ER0000.sl2|Elden Ring Coop Save File|ER0000.co2";
             DialogResult result = openFileDialog.ShowDialog(); // Show the dialog.
             if (result == DialogResult.OK) // Test result.
             {
@@ -112,7 +113,8 @@ namespace EldenRingSaveCopy
             targetSaveGames.Clear();
             OpenFileDialog openFileDialog = new OpenFileDialog();
             setCurrentUserDirectory(ref openFileDialog);
-            openFileDialog.Filter = "Elden Ring Save File |ER0000.sl2|Elden Ring Coop Save File |ER0000.co2";
+            openFileDialog.Filter = "All Elden Ring Save File Types|*.sl2;*.co2|"
+            + "Elden Ring Save File|ER0000.sl2|Elden Ring Coop Save File|ER0000.co2";
             DialogResult result = openFileDialog.ShowDialog();
             if (result == DialogResult.OK)
             {


### PR DESCRIPTION
Added to the Open File Dialogs a file type selection option, as the new default one, labeled: "All Elden Ring Save File Types" which allows both *.sl2 and *.co2 file types to be selected.

This because the Seamless COOP Mod added support for both *.sl2 and *.co2 file types.

![image](https://user-images.githubusercontent.com/5017552/210812001-807e88ca-2425-46b3-a1c6-1e0e0d7b51be.png)
![image](https://user-images.githubusercontent.com/5017552/210814433-b1b537d0-c13b-4688-89ca-842072327961.png)